### PR TITLE
Update TI to SVD access mapping based on SVD spec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,8 @@ fn write_access<O>(args: &Args, xml_out: &mut xml::EventWriter<&mut O>, ti_acces
     O: io::Write,
 {
     let access = match ti_access {
-        "RO" => "read",
-        "WO" => "write",
+        "RO" => "read-only",
+        "WO" => "write-only",
         "RW" => "read-write",
         unknown => {
             if !args.silent {
@@ -632,6 +632,7 @@ pub fn process_peripheral_base<I, O>(
                             };
                         }
 
+
                         if let Some(end_int) = f_end {
 
                             // Trust f_begin more than f_width
@@ -693,10 +694,8 @@ pub fn process_peripheral_base<I, O>(
                                 write_tag(args, &mut xml_out, "bitRange", &range)?;
                             }
                         }
-
-                        if let Some(_rwaccess) = f_rwaccess {
-                            // NOTE: This is a workaround for svd2rust not handling "read" access.
-                            //write_tag(args, &mut xml_out, "{}", process_access(rwaccess.as_ref()));
+                        if let Some(rwaccess) = f_rwaccess {
+                            write_access(args, &mut xml_out, &rwaccess)?;
                         }
                     },
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -504,7 +504,8 @@ pub fn process_peripheral_base<I, O>(
                         let mut f_value: Option<String> = None;
                         let mut f_width: Option<String> = None;
                         let mut f_description: Option<String> = None;
-                        let mut f_rwaccess: Option<String> = None;
+                        // Assume access is read-write if not specified, and let further restrictions be applied by the bitfilelds
+                        let mut f_rwaccess: Option<String> = Some("RW".to_string());
                         let mut f_offset: Option<String> = None;
                         let mut f_resetval: Option<String> = None;
 


### PR DESCRIPTION
 * Schema here shows mapping: https://www.keil.com/pack/doc/CMSIS/SVD/html/schema_1_2_gr.html
 * Generate access on bitfilds as well
 * Working on svd2rust 0.33.1