### PR TITLE
bug: fixing issue with missing field names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target/
+vscode/
+Cargo.lock


### PR DESCRIPTION
When trying to use this tool for ti radar boards the downstream svd2rust tool was failing due to missing field names.  I added code to fix this issue by populating name on other content if its missing.  