### PR TITLE
skip instances with id="Cp15" or "Vfp"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,6 +325,8 @@ pub fn process_device_base<I, O>(
                             // If no ID present, ignore the module (TI-internal?)
                             if skip {
                                 eprintln!("Sub-instance href does not start with Modules, or is missing. Skipping: '{:?}'", id);
+                            } else if id == "Cp15" || id == "Vfp" {
+                                eprintln!("Peripheral id {:?} suggests co-processor registers; Ignoring", id);
                             } else {
                                 if id.len() > 0 {
                                     if !printed_peripherals_tag {


### PR DESCRIPTION
Recent versions of Code Composer Studio come with device files for TI's Hercules Cortex-R MCUs, and they have a peculiar feature. They have one or both of a "Cp15" and "Vfp" instance under the comment "Additional Core Registers", with baseaddrs of 0xfff7c000 and 0xfff7c200. These coprocessor registers aren't actually mapped into the MCU's address space, and the registers described in the href'd module XML don't have any offset attribute. Additionally, many of these parts *do* have the MIBADC1 and MIBADC2 peripherals mapped at 0xfffc0000 and 0xfffc2000.

There aren't any devices defined with valid memory-mapped peripherals named Cp15 or Vfp, and I don't think it's likely that there will be in the future, so I think the simplest way to identify these rascals at the moment is by their IDs. If that seems too brittle to y'all, I can try to find a more complex heuristic that digs deeper into the module XML and send a revised PR, just let me know.