### PR TITLE
AM2xxx support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,16 @@ where
         "R/W" => "read-write",
         "R/W1TC" => "read-write",
         "R/W1TS" => "read-write",
+        "W1TC" => "write-only",
+        "W1TS" => "write-only",
+        "R/W1C" => "read-write",
+        "R/WD" => "read-write",
+        "R/WI" => "read-write",
+        "R/W0TC" => "read-write",
+        "R/WTC" => "read-write",
+        "R/WTD" => "read-write",
+        "R/R/WONCE" => "read-writeOnce",
+        "NU1" | "NU2" | "N/A" => return Ok(()), // Not used - skip silently
         unknown => {
             if !args.silent {
                 eprintln!("Ignoring unknown access key '{}'", unknown);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,25 @@ impl Args {
     }
 }
 
+/// Check if a reset value string has an errant `0x` prefix (a common TI XML bug
+/// where e.g. `0x32767` was meant as decimal `32767`). Returns the corrected
+/// decimal value if the decimal interpretation fits in the field.
+fn fix_errant_hex_prefix(val_str: &str, reg_width: u32, end_int: u32) -> Option<u64> {
+    if !val_str.starts_with("0x") && !val_str.starts_with("0X") {
+        return None;
+    }
+    let hex_str = &val_str[2..];
+    if !hex_str.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    let dec_val = u64::from_str(hex_str).ok()?;
+    let dec_overflow = dec_val >> (reg_width - end_int);
+    if dec_overflow != 0 {
+        return None;
+    }
+    Some(dec_val)
+}
+
 fn get_name_from_description(description: &str) -> String {
     let replaces = [
         (',', '_'),
@@ -921,6 +940,7 @@ where
                         let mut f_rwaccess: Option<String> = None;
                         let mut f_description: Option<String> = None;
                         let mut f_reset_value: Option<u64> = None;
+                        let mut f_resetval_str: Option<String> = None;
 
                         for attr in attributes {
                             let xml::attribute::OwnedAttribute { name, value } = attr;
@@ -970,17 +990,13 @@ where
                                     }
                                 }
                                 "resetval" => {
-                                    let resetval: Result<u64, std::num::ParseIntError>;
-                                    if value.starts_with("0x") {
-                                        resetval = u64::from_str_radix(&value[2..], 16);
-                                    } else {
-                                        resetval = u64::from_str(&value);
-                                    }
-                                    f_reset_value = match resetval {
-                                        Ok(x) => Some(x),
-                                        Err(_e) => None,
-                                    };
-                                    //f_reset_value = Some(resetval.unwrap());
+                                    f_resetval_str = Some(value.clone());
+                                    f_reset_value =
+                                        if value.starts_with("0x") || value.starts_with("0X") {
+                                            u64::from_str_radix(&value[2..], 16).ok()
+                                        } else {
+                                            u64::from_str(&value).ok()
+                                        };
                                 }
                                 unknown => {
                                     if args.verbose > 0 {
@@ -999,7 +1015,7 @@ where
                                 f_width = Some(begin_int - end_int + 1)
                             }
 
-                            if let Some(reset_value) = f_reset_value {
+                            if let Some(mut reset_value) = f_reset_value {
                                 let reg_width: u32 = register_width.unwrap_or(32);
 
                                 if let Some(width_int) = f_width {
@@ -1009,7 +1025,23 @@ where
                                 }
 
                                 if end_int < reg_width {
-                                    let overflow = reset_value >> (reg_width - end_int);
+                                    let mut overflow = reset_value >> (reg_width - end_int);
+
+                                    if overflow != 0 {
+                                        if let Some(ref val_str) = f_resetval_str {
+                                            if let Some(dec_val) = fix_errant_hex_prefix(val_str, reg_width, end_int) {
+                                                if !args.silent {
+                                                    eprintln!(
+                                                        "Resetval '{}' (hex {}) overflows field, using decimal {} instead",
+                                                        val_str, reset_value, dec_val
+                                                    );
+                                                }
+                                                reset_value = dec_val;
+                                                overflow = 0;
+                                            }
+                                        }
+                                    }
+
                                     if overflow == 0 {
                                         let shifted_reset_value = reset_value << end_int;
                                         if let Some(rrv) = register_reset_value {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 /// and peripheral descriptor files.
 extern crate xml;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use xml::writer;
 use xml::writer::EmitterConfig;
 
@@ -192,6 +192,27 @@ where
     write_content(args, xml_out, content)?;
     write_end(args, xml_out)?;
     Ok(())
+}
+
+fn write_start_with_attr<O>(
+    args: &Args,
+    xml_out: &mut xml::EventWriter<&mut O>,
+    name: &str,
+    attrs: &[(&str, &str)],
+) -> io::Result<()>
+where
+    O: io::Write,
+{
+    let mut element = writer::XmlEvent::start_element(name);
+    for (key, value) in attrs {
+        element = element.attr(*key, *value);
+    }
+    if args.verbose > 2 {
+        eprintln!("Writing start-tag with attrs: {:?}", name);
+    }
+    xml_out
+        .write(element)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))
 }
 
 /// Used by process_device_base to open each peripheral file and
@@ -390,6 +411,8 @@ where
     let mut cpunum = 0;
     let mut endianness: Option<String> = None;
     let mut device_attributes: Vec<OwnedAttribute> = vec![];
+    // Track which module hrefs have been processed and map to their first peripheral name
+    let mut module_to_peripheral: HashMap<String, String> = HashMap::new();
 
     for e in parser {
         match e {
@@ -528,6 +551,36 @@ where
                                         printed_peripherals_tag = true;
                                     }
 
+                                    // Check if this module href has been seen before
+                                    if let Some(ref href) = f_href {
+                                        if let Some(first_peripheral) =
+                                            module_to_peripheral.get(href)
+                                        {
+                                            // Use derivedFrom - write minimal peripheral
+                                            write_start_with_attr(
+                                                args,
+                                                &mut xml_out,
+                                                "peripheral",
+                                                &[("derivedFrom", first_peripheral)],
+                                            )?;
+                                            write_tag(args, &mut xml_out, "name", &id)?;
+                                            if let Some(ref baseaddr) = f_baseaddr {
+                                                write_tag(
+                                                    args,
+                                                    &mut xml_out,
+                                                    "baseAddress",
+                                                    baseaddr,
+                                                )?;
+                                            }
+                                            write_end(args, &mut xml_out)?;
+                                            continue;
+                                        } else {
+                                            // First time seeing this module - record it
+                                            module_to_peripheral.insert(href.clone(), id.clone());
+                                        }
+                                    }
+
+                                    // Write full peripheral definition
                                     write_start(args, &mut xml_out, "peripheral")?;
                                     write_tag(args, &mut xml_out, "name", &id)?;
 


### PR DESCRIPTION
Some fixes for AM2xxx support (tested on all in latest CCS) plus optimizations that fit all existing.

- Add SVD `derivedFrom` support for duplicate peripherals (e.g., AM2634.svd: 69MB to 9MB)
- Add support for additional TI access key types
- Fix obvious errant 0x prefix in resetval attributes where hex interpretation overflows but decimal fits (e.g.,  0x32767 to 32767), there are more that really look wrong - but they fit so I don't fix that

If the last one is too based, tell me and I'll drop that commit.